### PR TITLE
Added epub mimetype

### DIFF
--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/UriInterpretation.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/UriInterpretation.java
@@ -150,6 +150,10 @@ public class UriInterpretation {
 				mime = "application/json";
 				return;
 			}
+			if (extension.equals(".epub")) {
+				mime = "application/epub+zip";
+				return;
+			}
 
 		}
 


### PR DESCRIPTION
Sharing epub from android to ereaders requires that shareviahttp sets correct epub mime type.