### PR TITLE
Add launchMode="singleTask" to manifest.

### DIFF
--- a/ShareViaHttp/app/build.gradle
+++ b/ShareViaHttp/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.MarcosDiez.shareviahttp"
         minSdkVersion 14
         targetSdkVersion 30
-        versionCode 31
-        versionName "2.0.12"
+        versionCode 32
+        versionName "2.0.13"
         setProperty("archivesBaseName", "$applicationId-$versionName")
     }
 

--- a/ShareViaHttp/app/src/main/AndroidManifest.xml
+++ b/ShareViaHttp/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity
             android:name="com.MarcosDiez.shareviahttp.activities.MainActivity"
             android:configChanges="orientation|screenSize"
+            android:launchMode="singleTask"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -34,6 +35,7 @@
         <activity
             android:name="com.MarcosDiez.shareviahttp.activities.SendFileActivity"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize"
             android:excludeFromRecents="true">
             <intent-filter>

--- a/ShareViaHttp/app/src/main/AndroidManifest.xml
+++ b/ShareViaHttp/app/src/main/AndroidManifest.xml
@@ -35,7 +35,6 @@
         <activity
             android:name="com.MarcosDiez.shareviahttp.activities.SendFileActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize"
             android:excludeFromRecents="true">
             <intent-filter>

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
@@ -374,16 +374,18 @@ public class HttpServerConnection implements Runnable {
         }
         if (location != null) {
             // we don't want cache for the root URL
-            try {
-                int pos = location.indexOf("://");
-                if (pos > 0 && pos < 10) {
-                    // so russians can download their files as well :)
-                    // but if a protocol like http://, than we may as well redirect
-                    location = URLEncoder.encode(location, "UTF-8");
-                    s("after urlencode location:" + location);
+            if (!location.startsWith("http")) {  //if it is already an URL leave it as it is
+                try {
+                    int pos = location.indexOf("://");
+                    if (pos > 0 && pos < 10) {
+                        // so russians can download their files as well :)
+                        // but if a protocol like http://, than we may as well redirect
+                        location = URLEncoder.encode(location, "UTF-8");
+                        s("after urlencode location:" + location);
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    s(Log.getStackTraceString(e));
                 }
-            } catch (UnsupportedEncodingException e) {
-                s(Log.getStackTraceString(e));
             }
 
             output.append("Location: ").append(location).append("\r\n"); // server name

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
@@ -374,7 +374,7 @@ public class HttpServerConnection implements Runnable {
         }
         if (location != null) {
             // we don't want cache for the root URL
-            if (!location.startsWith("http")) {  //if it is already an URL leave it as it is
+            if (!location.startsWith("http://") && !location.startsWith("https://")) {  //if it is already an URL leave it as it is
                 try {
                     int pos = location.indexOf("://");
                     if (pos > 0 && pos < 10) {

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/BaseActivity.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/BaseActivity.java
@@ -180,13 +180,13 @@ public class BaseActivity extends AppCompatActivity {
         uriPath.setText(output.toString());
     }
 
-    protected void initHttpServer(ArrayList<UriInterpretation> myUris) {
+    protected void initHttpServer(ArrayList<UriInterpretation> myUris, Class currentActivity) {
         if (myUris == null || myUris.size() == 0) {
             finish();
             return;
         }
 
-        Intent notificationIntent = new Intent(this, MainActivity.class);
+        Intent notificationIntent = new Intent(this, currentActivity);
         notificationIntent.setAction(Intent.ACTION_MAIN);
         notificationIntent.addCategory(Intent.CATEGORY_LAUNCHER);
         PendingIntent pIntent = PendingIntent.getActivity(this,0, notificationIntent, 0);

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/MainActivity.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/MainActivity.java
@@ -74,7 +74,7 @@ public class MainActivity extends BaseActivity {
         if (requestCode == REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             ArrayList<UriInterpretation> uriList = getFileUris(data);
             populateUriPath(uriList);
-            initHttpServer(uriList);
+            initHttpServer(uriList,MainActivity.class);
             saveServerUrlToClipboard();
             setLinkMessageToView();
             setViewsVisible();

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/SendFileActivity.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/SendFileActivity.java
@@ -32,6 +32,7 @@ import android.support.design.widget.Snackbar;
 import android.view.View;
 import android.widget.Button;
 
+import com.MarcosDiez.shareviahttp.MyHttpServer;
 import com.MarcosDiez.shareviahttp.R;
 import com.MarcosDiez.shareviahttp.UriInterpretation;
 
@@ -54,10 +55,13 @@ public class SendFileActivity extends BaseActivity {
         setupNavigationViews();
         createViewClickListener();
 
-        uriList = getFileUris();
-
+        if (getIntent().getAction().equals(Intent.ACTION_MAIN)) {  // if click on notification
+            uriList= MyHttpServer.GetFiles();
+        } else  {
+            uriList = getFileUris();
+        }
         populateUriPath(uriList);
-        initHttpServer(uriList);
+        initHttpServer(uriList, SendFileActivity.class);
         saveServerUrlToClipboard();
         setLinkMessageToView();
         setupShareContainingFolderButton(uriList);


### PR DESCRIPTION
On some devices a click on the "Server running"  notification opens a "new" task without showing the buttons for stopping server, etc.

This does not happen when installing the app directly from Android Studio. But if a debug or release apk is generated and installed the problem shows up.

with "singleTask" in Manifest this is fixed.