### PR TITLE
Add dark mode

### DIFF
--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/MainActivity.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/activities/MainActivity.java
@@ -97,6 +97,7 @@ public class MainActivity extends BaseActivity {
         if (!"".equals(savedInstanceState.getCharSequence("uriPath"))) {
             setViewsVisible();
         }
+        generateBarCodeIfPossible();
     }
 
     @Override

--- a/ShareViaHttp/app/src/main/res/layout-v21/toolbar.xml
+++ b/ShareViaHttp/app/src/main/res/layout-v21/toolbar.xml
@@ -7,5 +7,5 @@
     android:background="@color/dark_blue"
     android:elevation="4dp"
     android:minHeight="?attr/actionBarSize"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
     app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />

--- a/ShareViaHttp/app/src/main/res/values/styles.xml
+++ b/ShareViaHttp/app/src/main/res/values/styles.xml
@@ -2,11 +2,10 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/dark_blue</item>
         <item name="colorPrimaryDark">@color/darker_blue</item>
         <item name="colorAccent">@color/dark_blue</item>
-        <item name="android:windowBackground">@color/white</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Closes #70

# What

Added basic dark mode support

# Why

Because it looks nice

# How

- use `AppCompat.DayNight` as the theme rather than `AppCompat.Light`
- fixed a bug where the qr code would disappear by changing themes. Simple regenerate the image after the instance state is restored

# Test

Tested on Android 14 that the app still functions as before, and everything is still legible in dark and light mode.

# See

See recording of the app in dark mode


https://github.com/marcosdiez/shareviahttp/assets/168225303/a0c56ce5-5d6f-4820-b9fc-a749d5eba151

Great app by the way, been using it for many years :smiley: 