### PR TITLE
add ACCESS_MEDIA_LOCATION permission, so GPS information is preserved in .JPG EXIF

### DIFF
--- a/ShareViaHttp/app/src/main/AndroidManifest.xml
+++ b/ShareViaHttp/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 


### PR DESCRIPTION
Fixes: https://github.com/marcosdiez/shareviahttp/issues/84


Tested that it works on my Android 14 device; debug `.apk` is available [here](https://github.com/mnalis/shareviahttp/actions/runs/15573022909) 

After applying this, Android 10+ preserves GPS EXIF location when shared via ShareViaHttp:

![small_Screenshot_20250611_022826_Permission controller](https://github.com/user-attachments/assets/a95610fc-9f24-4f63-8b48-a996c9ba322b)
