### PR TITLE
fix: App toolbar overlap with the status bar on Android 14+

### DIFF
--- a/ShareViaHttp/app/src/main/res/layout/activity_main.xml
+++ b/ShareViaHttp/app/src/main/res/layout/activity_main.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <include


### PR DESCRIPTION
Fixed App toolbar overlapping with the status bar on Android 14+ devices.

<img width="225" height="503" alt="Screenshot_20260104-214524_Share_via_HTTP 1" src="https://github.com/user-attachments/assets/4b28eea6-6312-45b1-9874-ab2e26359e32" />
