### PR TITLE
feat: add Content-Disposition and Accept-Ranges headers

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew app:assembleDebug
 
       - name: Upload Debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ShareViaHttp-debug-apk-${{ env.COMMIT_SHA }}
           path: ShareViaHttp/app/build/outputs/apk/debug/*.apk

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
@@ -389,13 +389,21 @@ public class HttpServerConnection implements Runnable {
     }
 
     // it is not always possible to get the file size :(
-    private String getFileSizeHeader() {
+    private String getFileSizeHeader(int return_code,long content_start,long content_end) {
         if (theUriInterpretation == null) {
             return "";
         }
-        if (fileUriZ.size() == 1 && theUriInterpretation.getSize() > 0) {
-            return "Content-Length: "
+        if ((return_code == 200 || return_code == 206) && fileUriZ.size() == 1) {
+            if(return_code == 206 && content_end >= content_start){
+                String lengthHeader = "Content-Length: " + Long.toString(content_end - content_start + 1) + "\r\n";
+                String rangeHeader = "Content-Range: bytes " + Long.toString(content_start) + "-" + Long.toString(content_end) + "/" + Long.toString(theUriInterpretation.getSize()) + "\r\n";
+                return rangeHeader + lengthHeader;
+            }
+            else if(theUriInterpretation.getSize() > 0)
+                return "Content-Length: "
                     + Long.toString(theUriInterpretation.getSize()) + "\r\n";
+            else
+                return "";
         }
         return "";
     }
@@ -413,18 +421,16 @@ public class HttpServerConnection implements Runnable {
         StringBuilder output = new StringBuilder();
         output.append("HTTP/1.0 ");
         output.append(httpReturnCodeToString(return_code) + "\r\n");
-        if(fileUriZ.size() == 1){
-            output.append("Accept-Ranges: bytes\n");
+        if((return_code == 200 || return_code == 206) && fileUriZ.size() == 1){
+            output.append("Accept-Ranges: bytes\r\n");
             try {
-                output.append("Content-Disposition: attachment; filename=\"" + theUriInterpretation.getName() + "\"; filename*=UTF-8''" + URLEncoder.encode(theUriInterpretation.getName(), "UTF-8") + "\n");
-                output.append("Content-Range: bytes " + Long.toString(content_start) + "-" + Long.toString(content_end) + "/" + Long.toString(theUriInterpretation.getSize()) + "\r\n");
-                if (content_end > content_start)
-                    output.append("Content-Length: " + Long.toString(content_end - content_start + 1) + "\r\n");
+                output.append("Content-Disposition: attachment; filename=\"" + theUriInterpretation.getName() + "\"; filename*=UTF-8''" + URLEncoder.encode(theUriInterpretation.getName(), "UTF-8") + "\r\n");
             }
             catch (UnsupportedEncodingException e){
                 s(Log.getStackTraceString(e));
             }
-        } else output.append(getFileSizeHeader());
+        }
+        output.append(getFileSizeHeader(return_code,content_start, content_end));
         SimpleDateFormat format = new SimpleDateFormat(
                 "EEE, dd MMM yyyy HH:mm:ss zzz");
 

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
@@ -411,6 +411,15 @@ public class HttpServerConnection implements Runnable {
         StringBuilder output = new StringBuilder();
         output.append("HTTP/1.0 ");
         output.append(httpReturnCodeToString(return_code) + "\r\n");
+        if(fileUriZ.size() == 1){
+            output.append("Accept-Ranges: bytes\n");
+            try {
+                output.append("Content-Disposition: attachment; filename=\"" + theUriInterpretation.getName() + "\"; filename*=UTF-8''" + URLEncoder.encode(theUriInterpretation.getName(), "UTF-8") + "\n");
+            }
+            catch (UnsupportedEncodingException e){
+                s(Log.getStackTraceString(e));
+            }
+        }
         if (content_start != 0 && content_end != -1) {
             output.append("Content-Range: bytes " + Long.toString(content_start) + "-" + Long.toString(content_end) + "/" + Long.toString(theUriInterpretation.getSize()) + "\r\n");
             if (content_end > content_start)

--- a/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
+++ b/ShareViaHttp/app/src/main/java/com/MarcosDiez/shareviahttp/HttpServerConnection.java
@@ -295,9 +295,11 @@ public class HttpServerConnection implements Runnable {
                     byte[] buffer = new byte[4096];
                     long sent = 0;
                     long rangeLength = (range_end - skipped) + 1;
-                    int n;
+                    Log.d("shareOneFile", "rangeLength : " + Long.toString(rangeLength));
+                    int n;//the total number of bytes read into the buffer, or -1 if there is no more data because the end of the file has been reached.
                     while (sent < rangeLength && (n = requestedfile.read(buffer)) != -1) {
                         if (sent + n > rangeLength) {
+                            Log.d("shareOneFile", "sent + n > rangeLength : sent=" + Long.toString(sent)+" n="+Integer.toString(n));
                             n = (int) (rangeLength - sent);
                         }
                         output.write(buffer, 0, n);
@@ -415,15 +417,13 @@ public class HttpServerConnection implements Runnable {
             output.append("Accept-Ranges: bytes\n");
             try {
                 output.append("Content-Disposition: attachment; filename=\"" + theUriInterpretation.getName() + "\"; filename*=UTF-8''" + URLEncoder.encode(theUriInterpretation.getName(), "UTF-8") + "\n");
+                output.append("Content-Range: bytes " + Long.toString(content_start) + "-" + Long.toString(content_end) + "/" + Long.toString(theUriInterpretation.getSize()) + "\r\n");
+                if (content_end > content_start)
+                    output.append("Content-Length: " + Long.toString(content_end - content_start + 1) + "\r\n");
             }
             catch (UnsupportedEncodingException e){
                 s(Log.getStackTraceString(e));
             }
-        }
-        if (content_start != 0 && content_end != -1) {
-            output.append("Content-Range: bytes " + Long.toString(content_start) + "-" + Long.toString(content_end) + "/" + Long.toString(theUriInterpretation.getSize()) + "\r\n");
-            if (content_end > content_start)
-                output.append("Content-Length: " + Long.toString(content_end - content_start + 1) + "\r\n");
         } else output.append(getFileSizeHeader());
         SimpleDateFormat format = new SimpleDateFormat(
                 "EEE, dd MMM yyyy HH:mm:ss zzz");


### PR DESCRIPTION
Now you can download the file with its filename using the curl command: `curl -L -OJ http://172.20.32.68:9999`
Example: `curl -L -OJ http://{ip}`

>`curl -L -I http://172.20.32.68:9999`

> HTTP/1.0 302 Moved Temporarily
> Accept-Ranges: bytes
> Content-Disposition: attachment; filename="keybox.xml"; filename*=UTF-8''keybox.xml
> Content-Length: 12689
> Date: Thu, 12 Feb 2026 00:09:29 IST
> Connection: close
> Server: ShareViaHttp 2.17
> Location: keybox.xml
> Expires: Tue, 03 Jul 2001 06:00:00 GMT
> Cache-Control: no-store, no-cache, must-revalidate, max-age=0
> Cache-Control: post-check=0, pre-check=0
> Pragma: no-cache
> 
> HTTP/1.0 200 OK
> Accept-Ranges: bytes
> Content-Disposition: attachment; filename="keybox.xml"; filename*=UTF-8''keybox.xml
> Content-Length: 12689
> Date: Thu, 12 Feb 2026 00:09:29 IST
> Connection: close
> Server: ShareViaHttp 2.17
> Content-Type: text/xml

